### PR TITLE
Fix playlist comment parsing

### DIFF
--- a/daily_fetch.py
+++ b/daily_fetch.py
@@ -82,11 +82,12 @@ def read_playlists(path: str = "playlists.txt") -> List[str]:
     p = pathlib.Path(path)
     if not p.exists():
         return []
-    return [
-        l.split("#", 1)[0].strip()
-        for l in p.read_text(encoding="utf-8").splitlines()
-        if l.strip()
-    ]
+    res: List[str] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            res.append(line)
+    return res
 
 
 def safe_execute(req, retries: int = 3):


### PR DESCRIPTION
## Summary
- clean comment-only lines when loading playlist IDs

## Testing
- `python3 -m py_compile daily_fetch.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8706990c832eb5553f77eaac25a4