### PR TITLE
Fix playlist comment parsing

### DIFF
--- a/.github/workflows/download-and-index.yml
+++ b/.github/workflows/download-and-index.yml
@@ -81,7 +81,7 @@ jobs:
             --uri "https://management.azure.com/subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/resourceGroups/${{ secrets.AZURE_RESOURCE_GROUP }}/providers/Microsoft.VideoIndexer/accounts/$VI_ACCOUNT_ID/generateAccessToken?api-version=2025-01-01" \
             --headers "Content-Type=application/json" \
             --body '{"permissionType":"Contributor","scope":"Account"}' \
-            --output json | jq -r '.accessToken')
+            --query accessToken --output tsv)
           
           if [ -z "$ACCESS_TOKEN" ]; then
             echo "Error: Failed to get Video Indexer access token."

--- a/daily_fetch.py
+++ b/daily_fetch.py
@@ -82,11 +82,12 @@ def read_playlists(path: str = "playlists.txt") -> List[str]:
     p = pathlib.Path(path)
     if not p.exists():
         return []
-    return [
-        l.split("#", 1)[0].strip()
-        for l in p.read_text(encoding="utf-8").splitlines()
-        if l.strip()
-    ]
+    res: List[str] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            res.append(line)
+    return res
 
 
 def safe_execute(req, retries: int = 3):


### PR DESCRIPTION
## Summary
- clean comment-only lines when loading playlist IDs
- simplify Video Indexer access token extraction

## Testing
- `python3 -m py_compile daily_fetch.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8706990c832eb5553f77eaac25a4